### PR TITLE
Output filename when sending sftp

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ that are otherwise encumbered.
 Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
+Written in 2020 by Arzang Kasiri - akasiri
 
 ===========================================================================
 
@@ -57,5 +58,6 @@ litigation is filed.
 Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
+Written in 2020 by Arzang Kasiri - akasiri
 
 ===========================================================================

--- a/service/org/moqui/sftp/SftpMessageServices.xml
+++ b/service/org/moqui/sftp/SftpMessageServices.xml
@@ -67,6 +67,8 @@ along with this software (see the LICENSE.md file). If not, see
                     sftpClient.close()
                 }
             ]]></script>
+
+            <set field="remoteMessageId" from="filename"/>
         </actions>
     </service>
 


### PR DESCRIPTION
`org.moqui.impl.SystemMessageServices.send#ProducedSystemMessage` expects a `remoteMessageId` in the send serivce's output. If it doesn't receive the `remoteMessageId`, it will end up overwriting the value with `null` when updating the SystemMessage.