### PR TITLE
Improved: put function to create directories if already does not exist

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,7 +36,7 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
 Written in 2020 by Arzang Kasiri - akasiri
-Written in 2023 by Vinayak Singh Bassan - VINSHOT75
+Written in 2023 by Vinayak Singh Bassan - Vinayak49
 
 ===========================================================================
 
@@ -60,6 +60,6 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
 Written in 2020 by Arzang Kasiri - akasiri
-Written in 2023 by Vinayak Singh Bassan - VINSHOT75
+Written in 2023 by Vinayak Singh Bassan - Vinayak49
 
 ===========================================================================

--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
 Written in 2020 by Arzang Kasiri - akasiri
+Written in 2023 by Vinayak Singh Bassan - VINSHOT75
 
 ===========================================================================
 
@@ -59,5 +60,6 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2019 by David E. Jones - jonesde
 Written in 2020 by Arzang Kasiri - akasiri
+Written in 2023 by Vinayak Singh Bassan - VINSHOT75
 
 ===========================================================================

--- a/src/main/groovy/org/moqui/sftp/SftpClient.groovy
+++ b/src/main/groovy/org/moqui/sftp/SftpClient.groovy
@@ -209,8 +209,13 @@ class SftpClient implements Closeable, AutoCloseable {
 
     /** Put a file from a text String; path may be to a target directory or file path, if directory filename is used as remote
      *     filename in path directory; the charset is used for the binary encoded, ie the charset to send to remote server */
-    SftpClient put(String path, String filename, String fileText, Charset charset = StandardCharsets.UTF_8) {
+    SftpClient put(String path, String filename, String fileText, Charset charset = StandardCharsets.UTF_8, boolean createDir = false) {
         if (sftpClient == null || !sshClient.isConnected()) throw new IllegalStateException("SFTP Client not connected")
+        if(createDir){
+            File file = new File(path)
+            String dirPath = file.parent
+            sftpClient.mkdirs(dirPath)
+        }
         ByteSourceFile bsf = new ByteSourceFile(filename, fileText, charset)
         sftpClient.put(bsf, path)
         return this

--- a/src/main/groovy/org/moqui/sftp/SftpClient.groovy
+++ b/src/main/groovy/org/moqui/sftp/SftpClient.groovy
@@ -211,7 +211,7 @@ class SftpClient implements Closeable, AutoCloseable {
      *     filename in path directory; the charset is used for the binary encoded, ie the charset to send to remote server */
     SftpClient put(String path, String filename, String fileText, Charset charset = StandardCharsets.UTF_8, boolean createDir = false) {
         if (sftpClient == null || !sshClient.isConnected()) throw new IllegalStateException("SFTP Client not connected")
-        if(createDir){
+        if (createDir){
             File file = new File(path)
             String dirPath = file.parent
             sftpClient.mkdirs(dirPath)


### PR DESCRIPTION
1. Added createDir parameter to put function and set to False, so that it does not disturb the existing use of function.
2. If createDir is passed as true, function will make directiories on the SFTP, if it already does not exist.